### PR TITLE
adding ntp & ntpdate to set & sync server clocks

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,3 +12,9 @@
     name: firewalld
     state: restarted
   become: true
+
+- name: restart ntpd
+  service:
+    name: ntpd
+    state: restarted
+  become: true

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -22,8 +22,8 @@ def test_ssh_config(host, file, content):
     assert f.contains(content)
 
 
-@pytest.mark.parametrize('svc', ['firewalld'])
-def test_firewalld_running(host, svc):
+@pytest.mark.parametrize('svc', ['firewalld', 'ntpd'])
+def test_services_running(host, svc):
     service = host.service(svc)
     assert service.is_running
     assert service.is_enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,8 @@
     - zip
     - unzip
     - policycoreutils-python
+    - ntp
+    - ntpdate
 
 - name: Set selinux to permissive mode
   selinux:
@@ -54,3 +56,20 @@
     state: enabled
     permanent: true
   notify: restart firewalld
+
+- name: Make sure ntpd is enabled
+  service:
+    name: ntpd
+    state: started
+    enabled: true
+
+- name: Run ntpdate to add specified CentOS NTP servers
+  command: ntpdate -u -s 0.centos.pool.ntp.org 1.centos.pool.ntp.org 2.centos.pool.ntp.org
+  register: ntpdate_output
+  notify: restart ntpd
+  changed_when: false
+
+- name: Set the hardware clock to current system time
+  command: hwclock -w
+  when: ntpdate_output == 0
+  changed_when: false


### PR DESCRIPTION
fixes JWT errors with Manifold on linode, which came from server clocks being out of sync.