### PR TITLE
Set hostname to inventory_hostname

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -21,3 +21,7 @@ def test_ssh_config(host, file, content):
     f = host.file(file)
     assert f.exists
     assert f.contains(content)
+
+
+def test_hostname(host):
+    host.file('/etc/hostname').contains("default")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,6 +76,10 @@
   when: ntpdate_output == 0
   changed_when: false
 
+- name: Set hostname
+  hostname:
+    name: "{{ inventory_hostname }}"
+
 - include: service.yml
   tags:
     - service-level


### PR DESCRIPTION
Useful for services that use hostname to identfy a michine, like DataDog
and Honeybadger.