### PR TITLE
MarkupSafe deprecation fix

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ ansible = "==2.9.20"
 cryptography = "==3.3.2"
 molecule = "*"
 molecule-docker = "*"
+markupsafe = "==2.0.1"
 
 [requires]
 python_version = "3.7"


### PR DESCRIPTION
Pins the version to 2.0.1. 

https://github.com/aws/aws-sam-cli/issues/3661#issuecomment-1044304978